### PR TITLE
Enable giscus comments in Quartz v5

### DIFF
--- a/quartz.config.yaml
+++ b/quartz.config.yaml
@@ -214,10 +214,15 @@ plugins:
       priority: 5
       condition: not-index
   - source: github:quartz-community/comments
-    enabled: false
+    enabled: true
     options:
       provider: giscus
-      options: {}
+      options:
+        repo: ananthakrishna7/ananthakrishna7.github.io
+        repoId: R_kgDOMaH4IA
+        category: Announcements
+        categoryId: DIC_kwDOMaH4IM4Cwuiu
+        lang: en
     layout:
       position: afterBody
       priority: 10


### PR DESCRIPTION
## Summary

- enable the pinned `quartz-community/comments` plugin in the v5 configuration
- carry forward the existing giscus repository and Announcements category identifiers from the v4 layout
- keep Quartz's documented `afterBody` placement and the v4-compatible defaults for URL mapping, strict matching, reactions, and input position

## Validation

- confirmed the repository is public and GitHub Discussions are enabled
- installed all 47 plugins from `quartz.lock.json`
- built Quartz v5 successfully from 111 Markdown inputs (318 emitted files)
- verified the generated HTML includes the expected `data-repo`, `data-repo-id`, `data-category`, `data-category-id`, and `data-lang` attributes

## References

- [Quartz comments documentation](https://quartz.jzhao.xyz/features/comments)
- [Official Quartz comments plugin](https://github.com/quartz-community/comments)
- [giscus configuration](https://giscus.app/)